### PR TITLE
feat: flag that allows to debug serialised blockchain transactions.

### DIFF
--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/LedgerDispatchStatus.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/LedgerDispatchStatus.java
@@ -12,7 +12,7 @@ public enum LedgerDispatchStatus {
 
     COMPLETED, // tx hash is ready and provided and in addition we have decent finality score to consider it completed
 
-    FINALIZED; // finalised on blockchain(s) - tx hash
+    FINALIZED; // finalised on blockchain(s) - tx hash (36 hours)
 
     public static Set<LedgerDispatchStatus> allDispatchedStatuses() {
         return Set.of(MARK_DISPATCH, DISPATCHED, COMPLETED, FINALIZED);


### PR DESCRIPTION
On Friday during a demo there seems to have been a problem that one transaction could not be serialised because metadata checker complained about creation_slot field in the metadata section. This PR introduces a feature flag which allows us to inspect transactions which are sent to the blockchain and analyse and store them on disk.


Ticket: [LOB-443](https://cardanofoundation.atlassian.net/browse/LOB-443)