### PR TITLE
fix: ready to publish endpoint rename

### DIFF
--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/AccountingCoreResource.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/AccountingCoreResource.java
@@ -172,7 +172,7 @@ public class AccountingCoreResource {
     }
 
     @Tag(name = "Transactions", description = "Transactions Publish / Dispatch Approval API")
-    @PostMapping(value = "/transactions/approve-dispatch", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/transactions/publish", produces = APPLICATION_JSON_VALUE, consumes = APPLICATION_JSON_VALUE)
     @Operation(description = "Approve to publish one or more transactions",
             responses = {
                     @ApiResponse(content = {


### PR DESCRIPTION
Rename endpoint from `/api/transactions/approve-dispatch` to `/api/transactions/publish`.