### PR TITLE
fix: making sure not all columns are used in blockchain publisher, we…

### DIFF
--- a/blockchain_publisher/src/main/java/org/cardanofoundation/lob/app/blockchain_publisher/domain/entity/TransactionEntity.java
+++ b/blockchain_publisher/src/main/java/org/cardanofoundation/lob/app/blockchain_publisher/domain/entity/TransactionEntity.java
@@ -6,10 +6,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.TransactionType;
-import org.cardanofoundation.lob.app.support.spring_audit.CommonEntity;
+import org.cardanofoundation.lob.app.support.spring_audit.CommonDateOnlyEntity;
 import org.hibernate.annotations.JdbcType;
 import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.annotation.Nullable;
 import java.time.LocalDate;
@@ -28,7 +29,8 @@ import static jakarta.persistence.FetchType.EAGER;
 @Table(name = "blockchain_publisher_transaction")
 @NoArgsConstructor
 @AllArgsConstructor
-public class TransactionEntity extends CommonEntity implements Persistable<String> {
+@EntityListeners({ AuditingEntityListener.class })
+public class TransactionEntity extends CommonDateOnlyEntity implements Persistable<String> {
 
     @Id
     @Column(name = "transaction_id", nullable = false)

--- a/blockchain_publisher/src/main/java/org/cardanofoundation/lob/app/blockchain_publisher/domain/entity/TransactionItemEntity.java
+++ b/blockchain_publisher/src/main/java/org/cardanofoundation/lob/app/blockchain_publisher/domain/entity/TransactionItemEntity.java
@@ -6,8 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.cardanofoundation.lob.app.support.spring_audit.CommonEntity;
+import org.cardanofoundation.lob.app.support.spring_audit.CommonDateOnlyEntity;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
@@ -21,7 +22,8 @@ import static jakarta.persistence.FetchType.EAGER;
 @Table(name = "blockchain_publisher_transaction_item")
 @NoArgsConstructor
 @AllArgsConstructor
-public class TransactionItemEntity extends CommonEntity implements Persistable<String> {
+@EntityListeners({ AuditingEntityListener.class })
+public class TransactionItemEntity extends CommonDateOnlyEntity implements Persistable<String> {
 
     @Id
     @Column(name = "transaction_item_id", nullable = false)

--- a/blockchain_publisher/src/main/resources/db/migration/postgresql/common/V4.1__100_lob_service_app_blockchain_publisher_module.sql
+++ b/blockchain_publisher/src/main/resources/db/migration/postgresql/common/V4.1__100_lob_service_app_blockchain_publisher_module.sql
@@ -69,9 +69,6 @@ CREATE TABLE blockchain_publisher_transaction (
    l1_publish_status blockchain_publisher_blockchain_publish_status_type,
    l1_finality_score blockchain_publisher_finality_score_type,
 
-   created_by VARCHAR(255),
-   updated_by VARCHAR(255),
-
    created_at TIMESTAMP WITHOUT TIME ZONE,
    updated_at TIMESTAMP WITHOUT TIME ZONE,
 
@@ -106,8 +103,6 @@ CREATE TABLE blockchain_publisher_transaction_item (
    document_vat_customer_code VARCHAR(255),
    document_vat_rate DECIMAL(12, 8),
 
-   created_by VARCHAR(255),
-   updated_by VARCHAR(255),
    created_at TIMESTAMP WITHOUT TIME ZONE,
    updated_at TIMESTAMP WITHOUT TIME ZONE,
 

--- a/support/src/main/java/org/cardanofoundation/lob/app/support/spring_audit/CommonDateOnlyEntity.java
+++ b/support/src/main/java/org/cardanofoundation/lob/app/support/spring_audit/CommonDateOnlyEntity.java
@@ -1,0 +1,46 @@
+package org.cardanofoundation.lob.app.support.spring_audit;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.javers.core.metamodel.annotation.DiffIgnore;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.TemporalType.TIMESTAMP;
+
+@Setter
+@Getter
+@MappedSuperclass
+@NoArgsConstructor
+public abstract class CommonDateOnlyEntity {
+
+    @Temporal(TIMESTAMP)
+    @Column(name = "created_at")
+    @CreatedDate
+    @DiffIgnore
+    protected LocalDateTime createdAt;
+
+    @Temporal(TIMESTAMP)
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    @DiffIgnore
+    protected LocalDateTime updatedAt;
+
+    @Transient
+    @DiffIgnore
+    protected boolean isNew = true;
+
+    @PostLoad
+    void markNotNew() {
+        this.isNew = false;
+    }
+
+    public boolean isNew() {
+        return isNew;
+    }
+
+}


### PR DESCRIPTION
While working recently I noticed that all columns related to auditing are null and by digging deeper I found the reason.


This is a bug fix related to the fact that we do not have audit tables for blockchain publisher. However, even though we do not have audit tables because blockchain_publisher is on it's own audit table, then we still want to record transactions created_at and updated_at.

Here is the fixed version, we have created_at and updated_at timestamps:
![image](https://github.com/user-attachments/assets/fb51a206-d652-4300-8f55-e82e3352ae73)
