### PR TITLE
feat: first versions for a framework to get metrics from the backend

### DIFF
--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/metric/MetricEnum.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/domain/core/metric/MetricEnum.java
@@ -1,0 +1,15 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric;
+
+public enum MetricEnum {
+
+    BALANCE_SHEET,
+    INCOME_STATEMENT;
+
+    public enum SubMetric {
+        ASSET_CATEGORIES,
+        BALANCE_SHEET_OVERVIEW,
+        TOTAL_EXPENSES,
+        INCOME_STREAMS
+    }
+
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/exception/MetricNotFoundException.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/exception/MetricNotFoundException.java
@@ -1,0 +1,7 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.exception;
+
+public class MetricNotFoundException extends RuntimeException {
+    public MetricNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/repository/ReportRepository.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/repository/ReportRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -19,7 +22,6 @@ public interface ReportRepository extends JpaRepository<ReportEntity, String> {
              ORDER BY r.createdAt ASC, r.reportId ASC""")
     Set<ReportEntity> findDispatchableTransactions(@Param("organisationId") String organisationId,
                                                    Limit limit);
-
 
     @Query("""
             SELECT r FROM accounting_reporting_core.report.ReportEntity r
@@ -40,4 +42,13 @@ public interface ReportRepository extends JpaRepository<ReportEntity, String> {
              ORDER BY r.ver DESC, r.ledgerDispatchApproved ASC
              LIMIT 1""")
     Optional<ReportEntity> findLatestByIdControl(@Param("organisationId") String organisationId, @Param("idControl") String idControl);
+
+    @Query("""
+        SELECT r FROM accounting_reporting_core.report.ReportEntity r
+        WHERE r.organisation.id = :organisationId
+        AND r.date >= :startDate AND r.date <= :endDate
+        """)
+    List<ReportEntity> getReportEntitiesByDateBetween(@Param("organisationId") String organisationId,
+                                                      @Param("startDate") LocalDate startDate,
+                                                      @Param("endDate") LocalDate endDate);
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
@@ -1,0 +1,39 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.resource;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricView;
+import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/metrics")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+@Slf4j
+public class MetricController {
+
+    private final MetricService metricService;
+
+    @Tag(name = "Dashboard", description = "Available Dashboards")
+    @GetMapping(value = "/availableMetrics", produces = "application/json")
+    public ResponseEntity<MetricView> availableDashboards() {
+        return ResponseEntity.ok(new MetricView(metricService.getAvailableMetrics()));
+    }
+
+    @Tag(name = "Dashboard", description = "Get Data for Dashboard")
+    @PostMapping(value = "/data", produces = "application/json")
+    public ResponseEntity<Map<String, List<Object>>> getDashboardData(@RequestBody MetricView metricView) {
+        return ResponseEntity.ok(metricService.getData(metricView.getMetrics()));
+    }
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.resource;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.lob.app.accounting_reporting_core.resource.requests.GetMetricDataRequest;
 import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricDataResponse;
 import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricView;
 import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricService;
@@ -14,8 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/metrics")
@@ -26,15 +26,19 @@ public class MetricController {
 
     private final MetricService metricService;
 
-    @Tag(name = "Dashboard", description = "Available Dashboards")
+    @Tag(name = "Metrics", description = "Available Metrics")
     @GetMapping(value = "/availableMetrics", produces = "application/json")
     public ResponseEntity<MetricView> availableDashboards() {
         return ResponseEntity.ok(new MetricView(metricService.getAvailableMetrics()));
     }
 
-    @Tag(name = "Dashboard", description = "Get Data for Dashboard")
+    @Tag(name = "Metrics", description = "Get Data from Metrics")
     @PostMapping(value = "/data", produces = "application/json")
-    public ResponseEntity<MetricDataResponse> getDashboardData(@RequestBody MetricView metricView) {
-        return ResponseEntity.ok(new MetricDataResponse(metricService.getData(metricView.getMetrics(), metricView.getStartDate(), metricView.getEndDate())));
+    public ResponseEntity<MetricDataResponse> getDashboardData(@RequestBody GetMetricDataRequest getMetricDataRequest) {
+        return ResponseEntity.ok(new MetricDataResponse(metricService.getData(
+                getMetricDataRequest.getMetricView().getMetrics(),
+                getMetricDataRequest.getOrganisationID(),
+                Optional.ofNullable(getMetricDataRequest.getStartDate()),
+                Optional.ofNullable(getMetricDataRequest.getEndDate()))));
     }
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
@@ -35,6 +35,6 @@ public class MetricController {
     @Tag(name = "Dashboard", description = "Get Data for Dashboard")
     @PostMapping(value = "/data", produces = "application/json")
     public ResponseEntity<MetricDataResponse> getDashboardData(@RequestBody MetricView metricView) {
-        return ResponseEntity.ok(new MetricDataResponse(metricService.getData(metricView.getMetrics())));
+        return ResponseEntity.ok(new MetricDataResponse(metricService.getData(metricView.getMetrics(), metricView.getStartDate(), metricView.getEndDate())));
     }
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/MetricController.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.resource;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricDataResponse;
 import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricView;
 import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricService;
 import org.springframework.http.ResponseEntity;
@@ -33,7 +34,7 @@ public class MetricController {
 
     @Tag(name = "Dashboard", description = "Get Data for Dashboard")
     @PostMapping(value = "/data", produces = "application/json")
-    public ResponseEntity<Map<String, List<Object>>> getDashboardData(@RequestBody MetricView metricView) {
-        return ResponseEntity.ok(metricService.getData(metricView.getMetrics()));
+    public ResponseEntity<MetricDataResponse> getDashboardData(@RequestBody MetricView metricView) {
+        return ResponseEntity.ok(new MetricDataResponse(metricService.getData(metricView.getMetrics())));
     }
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/requests/GetMetricDataRequest.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/requests/GetMetricDataRequest.java
@@ -1,0 +1,22 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.resource.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricView;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetMetricDataRequest {
+
+    String organisationID;
+    MetricView metricView;
+    LocalDateTime startDate;
+    LocalDateTime endDate;
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/requests/GetMetricDataRequest.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/requests/GetMetricDataRequest.java
@@ -6,8 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.cardanofoundation.lob.app.accounting_reporting_core.resource.views.MetricView;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
+import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -17,6 +16,6 @@ public class GetMetricDataRequest {
 
     String organisationID;
     MetricView metricView;
-    LocalDateTime startDate;
-    LocalDateTime endDate;
+    LocalDate startDate;
+    LocalDate endDate;
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricDataResponse.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricDataResponse.java
@@ -1,0 +1,18 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.resource.views;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MetricDataResponse {
+
+    Map<String, List<Object>> data;
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricDataResponse.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricDataResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
 
 import java.util.List;
 import java.util.Map;
@@ -14,5 +15,5 @@ import java.util.Map;
 @NoArgsConstructor
 public class MetricDataResponse {
 
-    Map<String, List<Object>> data;
+    Map<MetricEnum, List<Object>> data;
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
@@ -1,0 +1,19 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.resource.views;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MetricView {
+
+    Map<String, List<String>> metrics;
+
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
@@ -16,11 +16,5 @@ import java.util.Map;
 public class MetricView {
 
     Map<String, List<String>> metrics;
-    Date startDate;
-    Date endDate;
-
-    public MetricView(Map<String, List<String>> metrics) {
-        this.metrics = metrics;
-    }
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -15,5 +16,11 @@ import java.util.Map;
 public class MetricView {
 
     Map<String, List<String>> metrics;
+    Date startDate;
+    Date endDate;
+
+    public MetricView(Map<String, List<String>> metrics) {
+        this.metrics = metrics;
+    }
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/MetricView.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
 
 import java.util.Date;
 import java.util.List;
@@ -15,6 +16,6 @@ import java.util.Map;
 @NoArgsConstructor
 public class MetricView {
 
-    Map<String, List<String>> metrics;
+    Map<MetricEnum, List<MetricEnum.SubMetric>> metrics;
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
@@ -1,0 +1,31 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
+
+import lombok.Getter;
+import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class MetricExecutor {
+
+    protected Map<String, MetricFunction> metrics;
+
+    @Getter
+    protected String name;
+
+    public List<String> getAvailableMetrics() {
+        return Optional.ofNullable(metrics)
+                .orElseThrow(() -> new MetricNotFoundException(String.format("Metrics %s not initialized", name)))
+                .keySet().stream().toList();
+    }
+
+    public Object getData(String id) {
+        Map<String, MetricFunction> metricsNotInitialized = Optional.ofNullable(metrics).orElseThrow(() -> new MetricNotFoundException("Metrics not initialized"));
+        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, () -> {
+            throw new MetricNotFoundException(String.format("Metric Function %s not found in %s", id, name));
+        });
+        return metricFunction.getData();
+    }
+
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
@@ -3,7 +3,7 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal
 import lombok.Getter;
 import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -21,12 +21,12 @@ public abstract class MetricExecutor {
                 .keySet().stream().toList();
     }
 
-    public Object getData(String id, Date startDate, Date endDate) {
+    public Object getData(String id, String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate) {
         Map<String, MetricFunction> metricsNotInitialized = Optional.ofNullable(metrics).orElseThrow(() -> new MetricNotFoundException("Metrics not initialized"));
-        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, (Date start, Date end) -> {
+        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, (String orgId, Optional<LocalDateTime> start, Optional<LocalDateTime> end) -> {
             throw new MetricNotFoundException(String.format("Metric Function %s not found in %s", id, name));
         });
-        return metricFunction.getData(startDate, endDate);
+        return metricFunction.getData(organisationID, startDate, endDate);
     }
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
@@ -1,30 +1,31 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
 import lombok.Getter;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
 import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public abstract class MetricExecutor {
 
-    protected Map<String, MetricFunction> metrics;
+    protected Map<MetricEnum.SubMetric, MetricFunction> metrics;
 
     @Getter
-    protected String name;
+    protected MetricEnum name;
 
-    public List<String> getAvailableMetrics() {
+    public List<MetricEnum.SubMetric> getAvailableMetrics() {
         return Optional.ofNullable(metrics)
                 .orElseThrow(() -> new MetricNotFoundException(String.format("Metrics %s not initialized", name)))
                 .keySet().stream().toList();
     }
 
-    public Object getData(String id, String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate) {
-        Map<String, MetricFunction> metricsNotInitialized = Optional.ofNullable(metrics).orElseThrow(() -> new MetricNotFoundException("Metrics not initialized"));
-        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, (String orgId, Optional<LocalDateTime> start, Optional<LocalDateTime> end) -> {
-            throw new MetricNotFoundException(String.format("Metric Function %s not found in %s", id, name));
+    public Object getData(MetricEnum.SubMetric id, String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
+        Map<MetricEnum.SubMetric, MetricFunction> metricsNotInitialized = Optional.ofNullable(metrics).orElseThrow(() -> new MetricNotFoundException("Metrics not initialized"));
+        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, (String orgId, Optional<LocalDate> start, Optional<LocalDate> end) -> {
+            throw new MetricNotFoundException(String.format("Metric Function %s not found in %s", id.toString(), name));
         });
         return metricFunction.getData(organisationID, startDate, endDate);
     }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
@@ -23,7 +23,7 @@ public abstract class MetricExecutor {
 
     public Object getData(String id, Date startDate, Date endDate) {
         Map<String, MetricFunction> metricsNotInitialized = Optional.ofNullable(metrics).orElseThrow(() -> new MetricNotFoundException("Metrics not initialized"));
-        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, () -> {
+        MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, (Date start, Date end) -> {
             throw new MetricNotFoundException(String.format("Metric Function %s not found in %s", id, name));
         });
         return metricFunction.getData(startDate, endDate);

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricExecutor.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal
 import lombok.Getter;
 import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,12 +21,12 @@ public abstract class MetricExecutor {
                 .keySet().stream().toList();
     }
 
-    public Object getData(String id) {
+    public Object getData(String id, Date startDate, Date endDate) {
         Map<String, MetricFunction> metricsNotInitialized = Optional.ofNullable(metrics).orElseThrow(() -> new MetricNotFoundException("Metrics not initialized"));
         MetricFunction metricFunction = metricsNotInitialized.getOrDefault(id, () -> {
             throw new MetricNotFoundException(String.format("Metric Function %s not found in %s", id, name));
         });
-        return metricFunction.getData();
+        return metricFunction.getData(startDate, endDate);
     }
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
@@ -1,8 +1,10 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
+import java.util.Date;
+
 @FunctionalInterface
 public interface MetricFunction {
 
-    Object getData();
+    Object getData(Date startDate, Date endDate);
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
@@ -1,10 +1,11 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @FunctionalInterface
 public interface MetricFunction {
 
-    Object getData(Date startDate, Date endDate);
+    Object getData(String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate);
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
@@ -1,0 +1,8 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
+
+@FunctionalInterface
+public interface MetricFunction {
+
+    Object getData();
+
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricFunction.java
@@ -1,11 +1,12 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 @FunctionalInterface
 public interface MetricFunction {
 
-    Object getData(String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate);
+    Object getData(String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate);
 
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
@@ -1,10 +1,11 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 public interface MetricService {
 
     Map<String, List<String>> getAvailableMetrics();
-    Map<String, List<Object>> getData(Map<String, List<String>> metrics);
+    Map<String, List<Object>> getData(Map<String, List<String>> metrics, Date startDate, Date endDate);
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
@@ -1,11 +1,12 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface MetricService {
 
     Map<String, List<String>> getAvailableMetrics();
-    Map<String, List<Object>> getData(Map<String, List<String>> metrics, Date startDate, Date endDate);
+    Map<String, List<Object>> getData(Map<String, List<String>> metrics, String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate);
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
@@ -1,0 +1,10 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MetricService {
+
+    Map<String, List<String>> getAvailableMetrics();
+    Map<String, List<Object>> getData(Map<String, List<String>> metrics);
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricService.java
@@ -1,12 +1,14 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
-import java.time.LocalDateTime;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public interface MetricService {
 
-    Map<String, List<String>> getAvailableMetrics();
-    Map<String, List<Object>> getData(Map<String, List<String>> metrics, String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate);
+    Map<MetricEnum, List<MetricEnum.SubMetric>> getAvailableMetrics();
+    Map<MetricEnum, List<Object>> getData(Map<MetricEnum, List<MetricEnum.SubMetric>>  metrics, String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate);
 }

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,11 +23,11 @@ public class MetricServiceImpl implements MetricService{
     }
 
     @Override
-    public Map<String, List<Object>> getData(Map<String, List<String>> metrics) {
+    public Map<String, List<Object>> getData(Map<String, List<String>> metrics, Date startDate, Date endDate) {
         return metrics.entrySet().stream()
                 .map(metric -> {
                     MetricExecutor metricExecutor = getMetricExecutor(metric.getKey());
-                    List<Object> metricData = metric.getValue().stream().map(metricExecutor::getData).toList();
+                    List<Object> metricData = metric.getValue().stream().map(s -> metricExecutor.getData(s, startDate, endDate)).toList();
 
                     return Map.entry(metric.getKey(), metricData);
                 }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
@@ -4,9 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,11 +24,11 @@ public class MetricServiceImpl implements MetricService{
     }
 
     @Override
-    public Map<String, List<Object>> getData(Map<String, List<String>> metrics, Date startDate, Date endDate) {
+    public Map<String, List<Object>> getData(Map<String, List<String>> metrics, String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate) {
         return metrics.entrySet().stream()
                 .map(metric -> {
                     MetricExecutor metricExecutor = getMetricExecutor(metric.getKey());
-                    List<Object> metricData = metric.getValue().stream().map(s -> metricExecutor.getData(s, startDate, endDate)).toList();
+                    List<Object> metricData = metric.getValue().stream().map(s -> metricExecutor.getData(s,organisationID, startDate, endDate)).toList();
 
                     return Map.entry(metric.getKey(), metricData);
                 }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
@@ -1,0 +1,43 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
+
+import lombok.RequiredArgsConstructor;
+import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MetricServiceImpl implements MetricService{
+
+    private final List<MetricExecutor> metricExecutors;
+
+    public Map<String, List<String>> getAvailableMetrics() {
+        return metricExecutors.stream()
+                .map(metricExecutorInterface -> Map.entry(metricExecutorInterface.getName(),
+                        metricExecutorInterface.getAvailableMetrics()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, List<Object>> getData(Map<String, List<String>> metrics) {
+        return metrics.entrySet().stream()
+                .map(metric -> {
+                    MetricExecutor metricExecutor = getMetricExecutor(metric.getKey());
+                    List<Object> metricData = metric.getValue().stream().map(metricExecutor::getData).toList();
+
+                    return Map.entry(metric.getKey(), metricData);
+                }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private MetricExecutor getMetricExecutor(String metricName) {
+        return metricExecutors.stream()
+                .filter(metricExecutorInterface -> metricExecutorInterface.getName().equals(metricName))
+                .findFirst()
+                .orElseThrow(() -> new MetricNotFoundException(String.format("Metric %s not found", metricName)));
+    }
+
+
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/MetricServiceImpl.java
@@ -1,9 +1,11 @@
 package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics;
 
 import lombok.RequiredArgsConstructor;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
 import org.cardanofoundation.lob.app.accounting_reporting_core.exception.MetricNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +18,8 @@ public class MetricServiceImpl implements MetricService{
 
     private final List<MetricExecutor> metricExecutors;
 
-    public Map<String, List<String>> getAvailableMetrics() {
+    @Override
+    public Map<MetricEnum, List<MetricEnum.SubMetric>> getAvailableMetrics() {
         return metricExecutors.stream()
                 .map(metricExecutorInterface -> Map.entry(metricExecutorInterface.getName(),
                         metricExecutorInterface.getAvailableMetrics()))
@@ -24,7 +27,7 @@ public class MetricServiceImpl implements MetricService{
     }
 
     @Override
-    public Map<String, List<Object>> getData(Map<String, List<String>> metrics, String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate) {
+    public Map<MetricEnum, List<Object>> getData(Map<MetricEnum, List<MetricEnum.SubMetric>>  metrics, String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
         return metrics.entrySet().stream()
                 .map(metric -> {
                     MetricExecutor metricExecutor = getMetricExecutor(metric.getKey());
@@ -34,7 +37,7 @@ public class MetricServiceImpl implements MetricService{
                 }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private MetricExecutor getMetricExecutor(String metricName) {
+    private MetricExecutor getMetricExecutor(MetricEnum metricName) {
         return metricExecutors.stream()
                 .filter(metricExecutorInterface -> metricExecutorInterface.getName().equals(metricName))
                 .findFirst()

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricExecutor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -20,7 +22,7 @@ public class BalanceSheetMetricService extends MetricExecutor {
         );
     }
 
-    private Map<String, Integer> getAssets(Date startDate, Date endDate) {
+    private Map<String, Integer> getAssets(String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate) {
         return Map.of(
                 "totalAssets", 1000
         );

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
@@ -2,13 +2,15 @@ package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
 import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricExecutor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum.BALANCE_SHEET;
 
 @Component
 @RequiredArgsConstructor
@@ -16,13 +18,20 @@ public class BalanceSheetMetricService extends MetricExecutor {
 
     @PostConstruct
     public void init() {
-        name = "BalanceSheet";
+        name = BALANCE_SHEET;
         metrics = Map.of(
-                "assets", this::getAssets
+                MetricEnum.SubMetric.ASSET_CATEGORIES, this::getAssetCategories,
+                MetricEnum.SubMetric.BALANCE_SHEET_OVERVIEW, this::getBalanceSheetOverview
         );
     }
 
-    private Map<String, Integer> getAssets(String organisationID, Optional<LocalDateTime> startDate, Optional<LocalDateTime> endDate) {
+    private Object getBalanceSheetOverview(String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
+        return Map.of(
+                "BalanceOverview", 1000
+        );
+    }
+
+    private Map<String, Integer> getAssetCategories(String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
         return Map.of(
                 "totalAssets", 1000
         );

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
@@ -1,0 +1,27 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.executors;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricExecutor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class BalanceSheetMetricService extends MetricExecutor {
+
+    @PostConstruct
+    public void init() {
+        name = "BalanceSheet";
+        metrics = Map.of(
+                "assets", this::getAssets
+        );
+    }
+
+    private Map<String, Integer> getAssets() {
+        return Map.of(
+                "totalAssets", 1000
+        );
+    }
+}

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/BalanceSheetMetricService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricExecutor;
 import org.springframework.stereotype.Component;
 
+import java.util.Date;
 import java.util.Map;
 
 @Component
@@ -19,7 +20,7 @@ public class BalanceSheetMetricService extends MetricExecutor {
         );
     }
 
-    private Map<String, Integer> getAssets() {
+    private Map<String, Integer> getAssets(Date startDate, Date endDate) {
         return Map.of(
                 "totalAssets", 1000
         );

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/IncomeStatementMetricService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/service/internal/metrics/executors/IncomeStatementMetricService.java
@@ -1,0 +1,89 @@
+package org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.executors;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.core.metric.MetricEnum;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.entity.report.IncomeStatementData;
+import org.cardanofoundation.lob.app.accounting_reporting_core.domain.entity.report.ReportEntity;
+import org.cardanofoundation.lob.app.accounting_reporting_core.repository.ReportRepository;
+import org.cardanofoundation.lob.app.accounting_reporting_core.service.internal.metrics.MetricExecutor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class IncomeStatementMetricService extends MetricExecutor {
+
+    private final ReportRepository reportRepository;
+
+    private static final String COST_OF_SERVICE = "Cost of Service";
+    private static final String PERSONNEL_EXPENSES = "Personnel Expenses";
+    private static final String FINANCIAL_EXPENSES = "Financial Expenses";
+    private static final String TAX_EXPENSES = "Tax Expenses";
+    private static final String OTHER_OPERATING_EXPENSES = "Other Operating Expenses";
+
+    @PostConstruct
+    public void init() {
+        name = MetricEnum.INCOME_STATEMENT;
+        metrics = Map.of(
+                MetricEnum.SubMetric.TOTAL_EXPENSES, this::getTotalExpenses,
+                MetricEnum.SubMetric.INCOME_STREAMS, this::getIncomeStream
+        );
+    }
+
+    private Map<String, Integer> getTotalExpenses(String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
+
+
+        List<ReportEntity> reportEntitiesByDateBetween = reportRepository.getReportEntitiesByDateBetween(organisationID,
+                startDate.orElse(LocalDate.MIN),
+                endDate.orElse(LocalDate.MAX));
+        Map<String, Integer> totalExpenses = new HashMap<>();
+
+        reportEntitiesByDateBetween.forEach(reportEntity -> {
+            if(reportEntity.getIncomeStatementReportData().isPresent()) {
+                IncomeStatementData incomeStatementData = reportEntity.getIncomeStatementReportData().get();
+                totalExpenses.merge(COST_OF_SERVICE, incomeStatementData.getCostOfGoodsAndServices()
+                        .orElse(new IncomeStatementData.CostOfGoodsAndServices()).getCostOfProvidingServices()
+                        .orElse(BigDecimal.ZERO).intValue(),
+                        Integer::sum);
+                totalExpenses.merge(PERSONNEL_EXPENSES, incomeStatementData.getOperatingExpenses()
+                        .orElse(new IncomeStatementData.OperatingExpenses()).getPersonnelExpenses()
+                        .orElse(BigDecimal.ZERO).intValue(),
+                        Integer::sum);
+                totalExpenses.merge(FINANCIAL_EXPENSES, incomeStatementData.getFinancialIncome()
+                        .orElse(new IncomeStatementData.FinancialIncome()).getFinancialExpenses()
+                        .orElse(BigDecimal.ZERO).intValue(),
+                        Integer::sum);
+                totalExpenses.merge(TAX_EXPENSES, incomeStatementData.getTaxExpenses()
+                        .orElse(new IncomeStatementData.TaxExpenses()).getIncomeTaxExpense()
+                        .orElse(BigDecimal.ZERO).intValue(),
+                        Integer::sum);
+                // Other Expenses
+                totalExpenses.put(OTHER_OPERATING_EXPENSES, 0);
+                if(incomeStatementData.getOperatingExpenses().isPresent()) {
+                    IncomeStatementData.OperatingExpenses operatingExpenses = incomeStatementData.getOperatingExpenses().get();
+                    int otherExpenses = 0;
+                    // TODO Check what's in other Expenses as well
+                    otherExpenses += operatingExpenses.getRentExpenses().orElse(BigDecimal.ZERO).intValue();
+                    otherExpenses += operatingExpenses.getGeneralAndAdministrativeExpenses().orElse(BigDecimal.ZERO).intValue();
+                    totalExpenses.merge(OTHER_OPERATING_EXPENSES, otherExpenses, Integer::sum);
+                }
+
+            }
+        });
+        return totalExpenses;
+    }
+
+    private Map<String, Integer> getIncomeStream(String organisationID, Optional<LocalDate> startDate, Optional<LocalDate> endDate) {
+        return Map.of(
+                "IncomeStreams", 1000
+        );
+    }
+
+}


### PR DESCRIPTION
Implemented controller + services as a basis to add metrics to the backend.
It is possible to get the available metrics and call the respective functions in the services. 

To add new metrics the developer must only implement the new Abstract class and fill the Metrics Map to map IDs to functions. 

The real functions to retrieve data will be added in a later step. 