### PR TITLE
feat: Return correct Authentication name for auditor

### DIFF
--- a/support/src/main/java/org/cardanofoundation/lob/app/support/spring_audit/internal/AuditDataProvider.java
+++ b/support/src/main/java/org/cardanofoundation/lob/app/support/spring_audit/internal/AuditDataProvider.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -24,15 +26,11 @@ public class AuditDataProvider implements AuditorAware<String>, DateTimeProvider
 
     @Override
     public Optional<String> getCurrentAuditor() {
-//        return Optional.ofNullable(SecurityContextHolder.getContext())
-//                .map(SecurityContext::getAuthentication)
-//                .filter(Authentication::isAuthenticated)
-//                .map(Authentication::getPrincipal)
-//                .map(User.class::cast)
-//                .map(User::getUsername);
-
-        // TODO find out logged in user
-        return Optional.of("system");
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            return Optional.of(authentication.getName());
+        }
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
@matiwinnetou @M4rc0Russ0 
As far as I saw we are using the CommonEntity nearly everywhere, so I added the User who made changes to the audit of this base entity. 
Are you aware of another field where this user information might be relevant, but not present with this solution?