### PR TITLE
feat: [LOB-1980] Add batchId field to TransactionReconciliationTransactionsView in /transactions-reconcile endpoint

### DIFF
--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/presentation_layer_service/AccountingCorePresentationViewService.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/presentation_layer_service/AccountingCorePresentationViewService.java
@@ -455,6 +455,7 @@ public class AccountingCorePresentationViewService {
         }
         return new TransactionReconciliationTransactionsView(transactionEntity.getId(),
                 transactionEntity.getInternalTransactionNumber(),
+                transactionEntity.getBatchId(),
                 transactionEntity.getEntryDate(),
                 transactionEntity.getTransactionType(), dataSourceView,
                 Optional.of(transactionEntity.getOverallStatus()),
@@ -504,6 +505,7 @@ public class AccountingCorePresentationViewService {
         return new TransactionReconciliationTransactionsView(
                 reconcilationViolation.getTransactionId(),
                 reconcilationViolation.getTransactionInternalNumber(),
+                null,
                 reconcilationViolation.getTransactionEntryDate(),
                 reconcilationViolation.getTransactionType(),
                 DataSourceView.NETSUITE, Optional.empty(), Optional.empty(),
@@ -520,7 +522,7 @@ public class AccountingCorePresentationViewService {
     }
 
     private TransactionReconciliationTransactionsView getTransactionReconciliationViolationView() {
-        return new TransactionReconciliationTransactionsView("", "", LocalDate.now(),
+        return new TransactionReconciliationTransactionsView("", "", null, LocalDate.now(),
                 TransactionType.CardCharge, DataSourceView.NETSUITE,
                 Optional.empty(), Optional.empty(), Optional.empty(), false, false,
                 BigDecimal.valueOf(123), false,

--- a/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/TransactionReconciliationTransactionsView.java
+++ b/accounting_reporting_core/src/main/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/views/TransactionReconciliationTransactionsView.java
@@ -32,6 +32,8 @@ public class TransactionReconciliationTransactionsView {
     private String id;
     private String internalTransactionNumber;
 
+    private String batchId;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate entryDate;
 

--- a/accounting_reporting_core/src/test/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/presentation_layer_service/AccountingCorePresentationViewServiceTest.java
+++ b/accounting_reporting_core/src/test/java/org/cardanofoundation/lob/app/accounting_reporting_core/resource/presentation_layer_service/AccountingCorePresentationViewServiceTest.java
@@ -911,6 +911,7 @@ class AccountingCorePresentationViewServiceTest {
         TransactionReconciliationTransactionsView view = result.getTransactions().iterator().next();
         assertEquals(lastReconciledDate, view.getReconciliationDate());
         assertEquals("TX-001", view.getId());
+        assertNull(view.getBatchId());
         assertEquals(TransactionReconciliationTransactionsView.ReconciliationCodeView.NOK, view.getReconciliationFinalStatus());
     }
 
@@ -949,6 +950,7 @@ class AccountingCorePresentationViewServiceTest {
     void getReconciliationTransactionsSelector_txPresent_usesTxPathAndIgnoresLastReconciledDate() {
         TransactionEntity txEntity = mock(TransactionEntity.class);
         when(txEntity.getId()).thenReturn("TX-003");
+        when (txEntity.getBatchId()).thenReturn("batch-123");
         when(txEntity.getExtractorType()).thenReturn("NETSUITE");
         when(txEntity.getOverallStatus()).thenReturn(TransactionStatus.OK);
         when(txEntity.getAutomatedValidationStatus()).thenReturn(TxValidationStatus.VALIDATED);
@@ -973,6 +975,7 @@ class AccountingCorePresentationViewServiceTest {
         assertEquals(1, result.getTransactions().size());
         TransactionReconciliationTransactionsView view = result.getTransactions().iterator().next();
         assertEquals("TX-003", view.getId());
+        assertEquals("batch-123", view.getBatchId());
         // lastReconciledDate from the DTO is not used in this path — the tx's own reconciliation data is used
         assertNull(view.getReconciliationDate());
     }
@@ -998,6 +1001,7 @@ class AccountingCorePresentationViewServiceTest {
         TransactionReconciliationTransactionsView view = result.getTransactions().iterator().next();
         // fallback view returns empty string id and null reconciliation date
         assertEquals("", view.getId());
+        assertNull(view.getBatchId());
         assertNull(view.getReconciliationDate());
         assertEquals(TransactionReconciliationTransactionsView.ReconciliationCodeView.NOK, view.getReconciliationFinalStatus());
     }


### PR DESCRIPTION
## Subject

Add batchId field to TransactionReconciliationTransactionsView in /transactions-reconcile endpoint

## Changes Description

Added the batchid field to the TransactionReconciliationTransactionsView and fixed its uses in AccountingCorePresentationViewService.

## How to test

Added the batchid field to the tests
- getReconciliationTransactionsSelector_violationOnly_propagatesLastReconciledDate
- getReconciliationTransactionsSelector_txPresent_usesTxPathAndIgnoresLastReconciledDate
- getReconciliationTransactionsSelector_bothTxAndViolationNull_returnsFallbackView
in AccountingCorePresentationViewServiceTest

## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/LOB-1980
