### PR TITLE
fix: [LOB-1598] unify 409 error message returned from BE for setup tables

### DIFF
--- a/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/AccountEventService.java
+++ b/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/AccountEventService.java
@@ -97,7 +97,7 @@ public class AccountEventService {
 
         // If the account event already exists and we are not upserting, return an error
         if (accountEventOpt.isPresent() && !isUpsert) {
-            ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Account event already exists for debit reference code: %s and credit reference code: %s".formatted(eventCodeUpdate.getDebitReferenceCode(), eventCodeUpdate.getCreditReferenceCode()));
+            ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Account with debit reference code %s and credit reference code %s already exists.".formatted(eventCodeUpdate.getDebitReferenceCode(), eventCodeUpdate.getCreditReferenceCode()));
             problem.setTitle(ErrorTitleConstants.ACCOUNT_EVENT_ALREADY_EXISTS);
             return AccountEventView.createFail(problem, eventCodeUpdate);
         }

--- a/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/ChartOfAccountsService.java
+++ b/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/ChartOfAccountsService.java
@@ -201,7 +201,7 @@ public class ChartOfAccountsService {
             if (isUpsert) {
                 chartOfAccount = chartOfAccountOpt.get();
             } else {
-                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "The chart of account with code: %s already exists".formatted(chartOfAccountUpdate.getCustomerCode()));
+                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Code %s already exists.".formatted(chartOfAccountUpdate.getCustomerCode()));
                 problem.setTitle("CHART_OF_ACCOUNT_ALREADY_EXISTS");
                 return ChartOfAccountView.createFail(problem, chartOfAccountUpdate);
             }

--- a/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/CostCenterService.java
+++ b/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/CostCenterService.java
@@ -108,7 +108,7 @@ public class CostCenterService {
         costCenter.setId(new CostCenter.Id(orgId, costCenterUpdate.getCustomerCode()));
         if (costCenterFound.isPresent()) {
             if (!isUpsert) {
-                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Cost Center with customer code %s already exists.".formatted(costCenterUpdate.getCustomerCode()));
+                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Code %s already exists.".formatted(costCenterUpdate.getCustomerCode()));
                 problem.setTitle(ErrorTitleConstants.COST_CENTER_CODE_ALREADY_EXISTS);
                 return CostCenterView.createFail(costCenterUpdate, problem);
             }

--- a/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/ReferenceCodeService.java
+++ b/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/ReferenceCodeService.java
@@ -85,7 +85,7 @@ public class ReferenceCodeService {
             if(isUpsert) {
                 referenceCode = referenceCodeOpt.get();
             } else {
-                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "The reference code with code :%s already exists".formatted(referenceCodeUpdate.getReferenceCode()));
+                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Code %s already exists.".formatted(referenceCodeUpdate.getReferenceCode()));
                 problem.setTitle(ErrorTitleConstants.REFERENCE_CODE_ALREADY_EXIST);
                 return ReferenceCodeView.createFail(problem, referenceCodeUpdate);
             }

--- a/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/VatService.java
+++ b/organisation/src/main/java/org/cardanofoundation/lob/app/organisation/service/VatService.java
@@ -75,7 +75,7 @@ public class VatService {
             if(isUpsert) {
                 vatEntity = foundEntity.get();
             } else {
-                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "The organisation vat with code :%s already exists".formatted(vatUpdate.getCustomerCode()));
+                ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Code %s already exists.".formatted(vatUpdate.getCustomerCode()));
                 problem.setTitle(ErrorTitleConstants.ORGANISATION_VAT_ALREADY_EXISTS);
                 return VatView.createFail(vatUpdate, problem);
             }

--- a/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/AccountEventServiceTest.java
+++ b/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/AccountEventServiceTest.java
@@ -305,6 +305,21 @@ class AccountEventServiceTest {
     }
 
     @Test
+    void testInsertReferenceCode_CodeAlreadyExistDetail() {
+        when(referenceCodeRepository.findByOrgIdAndReferenceCode(ORG_ID, DEBIT_REF_CODE)).thenReturn(Optional.of(mockDebitReference));
+        when(referenceCodeRepository.findByOrgIdAndReferenceCode(ORG_ID, CREDIT_REF_CODE)).thenReturn(Optional.of(mockCreditReference));
+        when(accountEventRepository.findByOrgIdAndDebitReferenceCodeAndCreditReferenceCode(ORG_ID, DEBIT_REF_CODE, CREDIT_REF_CODE))
+                .thenReturn(Optional.of(mockAccountEvent));
+        when(organisationService.findById(ORG_ID)).thenReturn(Optional.of(mockOrganisation));
+
+        AccountEventView result = accountEventService.insertAccountEvent(ORG_ID, mockEventCodeUpdate, false);
+
+        assertTrue(result.getError().isPresent());
+        assertEquals("Account with debit reference code " + DEBIT_REF_CODE + " and credit reference code " + CREDIT_REF_CODE + " already exists.", result.getError().get().getDetail());
+        verify(accountEventRepository, never()).save(any());
+    }
+
+    @Test
     void testInsertReferenceCode_FailsWhenDebitReferenceMissing() {
         when(referenceCodeRepository.findByOrgIdAndReferenceCode(ORG_ID, DEBIT_REF_CODE)).thenReturn(Optional.empty());
         when(organisationService.findById(ORG_ID)).thenReturn(Optional.of(mockOrganisation));

--- a/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/ChartOfAccountsServiceTest.java
+++ b/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/ChartOfAccountsServiceTest.java
@@ -499,6 +499,23 @@ class ChartOfAccountsServiceTest {
     }
 
     @Test
+    void testInsertChartOfAccount_ExistDetail() {
+        when(organisationService.findById(orgId)).thenReturn(Optional.of(new Organisation()));
+        when(referenceCodeRepository.findByOrgIdAndReferenceCode(orgId, chartOfAccountUpdate.getEventRefCode()))
+                .thenReturn(Optional.of(referenceCode));
+        when(chartOfAccountSubTypeRepository.findAllByOrganisationIdAndSubTypeId(orgId, chartOfAccountUpdate.getSubType()))
+                .thenReturn(Optional.of(subType));
+        when(chartOfAccountRepository.findAllByOrganisationIdAndReferenceCode(orgId, chartOfAccountUpdate.getCustomerCode()))
+                .thenReturn(Optional.of(chartOfAccount));
+
+        ChartOfAccountView response = chartOfAccountsService.insertChartOfAccount(orgId, chartOfAccountUpdate, false);
+
+        assertNotNull(response);
+        assertFalse(response.getError().isEmpty());
+        assertEquals("Code " + customerCode + " already exists.", response.getError().get().getDetail());
+    }
+
+    @Test
     void testInsertChartOfAccount_Success() {
         Organisation mockOrg = mock(Organisation.class);
         when(organisationService.findById(orgId)).thenReturn(Optional.of(mockOrg));

--- a/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/CostCenterServiceTest.java
+++ b/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/CostCenterServiceTest.java
@@ -210,6 +210,20 @@ class CostCenterServiceTest {
     }
 
     @Test
+    void insertCostCenter_costCenterAlreadyExistsDetail() {
+        CostCenterUpdate costCenterUpdate = mock(CostCenterUpdate.class);
+
+        when(costCenterUpdate.getCustomerCode()).thenReturn(customerCode);
+        when(costCenterRepository.findById(new CostCenter.Id(organisationId, customerCode))).thenReturn(Optional.of(costCenter));
+
+        CostCenterView costCenterView = costCenterService.insertCostCenter(organisationId, costCenterUpdate, false);
+
+        assertNotNull(costCenterView);
+        assertEquals(customerCode, costCenterView.getCustomerCode());
+        assertEquals("Code " + customerCode + " already exists.", costCenterView.getError().get().getDetail());
+    }
+
+    @Test
     void insertCostCenter_parentNotFound() {
         CostCenterUpdate costCenterUpdate = mock(CostCenterUpdate.class);
 

--- a/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/ReferenceCodeServiceTest.java
+++ b/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/ReferenceCodeServiceTest.java
@@ -302,6 +302,17 @@ class ReferenceCodeServiceTest {
     }
 
     @Test
+    void testInsertReferenceCode_UpdateExistingDetail() {
+        when(referenceCodeRepository.findByOrgIdAndReferenceCode(ORG_ID, REF_CODE)).thenReturn(Optional.of(referenceCode));
+        when(organisationService.findById(ORG_ID)).thenReturn(Optional.of(mockOrganisation));
+
+        ReferenceCodeView result = referenceCodeService.insertReferenceCode(ORG_ID, referenceCodeUpdate, false);
+
+        assertTrue(result.getError().isPresent());
+        assertEquals("Code " + REF_CODE + " already exists.", result.getError().get().getDetail());
+    }
+
+    @Test
     void testInsertReferenceCode_UpdateExistingNotFindParentCode() {
         when(referenceCodeRepository.findByOrgIdAndReferenceCode(ORG_ID, "0102")).thenReturn(Optional.empty());
         when(organisationService.findById(ORG_ID)).thenReturn(Optional.of(mockOrganisation));

--- a/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/VatServiceTest.java
+++ b/organisation/src/test/java/org/cardanofoundation/lob/app/organisation/service/VatServiceTest.java
@@ -74,6 +74,19 @@ class VatServiceTest {
     }
 
     @Test
+    void insert_alreadyExistsDetail() {
+        VatUpdate vatUpdate = mock(VatUpdate.class);
+        Vat.Id id = new Vat.Id("organisationId", "customerCode");
+        when(vatUpdate.getCustomerCode()).thenReturn("customerCode");
+        when(vatRepository.findById(id)).thenReturn(Optional.of(mock(Vat.class)));
+
+        VatView result = vatService.insert("organisationId", vatUpdate, false);
+
+        assertTrue(result.getError().isPresent());
+        assertEquals("Code customerCode already exists.", result.getError().get().getDetail());
+    }
+
+    @Test
     void insert_countryCodeNotExists() {
         VatUpdate update = mock(VatUpdate.class);
 


### PR DESCRIPTION
## Subject

Unify 409 error message returned from BE for setup tables

## Changes Description

Changed the Detail strings in the respective services.

## How to test

Every changed service has a test. The tests
- insert_alreadyExistsDetail (VatServiceTest)
- insertCostCenter_costCenterAlreadyExistsDetail (CostCenterServiceTest)
- testInsertChartOfAccount_ExistDetail (ChartOfAccountsServiceTest)
- testInsertReferenceCode_UpdateExistingDetail (ReferenceCodeServiceTest)
- testInsertReferenceCode_CodeAlreadyExistDetail (AccountEventServiceTest)

were added.

## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/LOB-1598
