### PR TITLE
fix: [LOB-2034] Cumulative Summing error in IS (prod)

### DIFF
--- a/reporting/src/main/java/org/cardanofoundation/lob/app/reporting/viewConverter/converter/IncomeStatementConverter.java
+++ b/reporting/src/main/java/org/cardanofoundation/lob/app/reporting/viewConverter/converter/IncomeStatementConverter.java
@@ -37,10 +37,7 @@ public class IncomeStatementConverter implements ResponseConverter {
             if(i > 0 && !field.getChildFields().isEmpty()) {
                 field.setValue(fields.get(i-1).getValue().add(field.getValue()));
             }
-            // Recursively convert child fields
-            if (field.getChildFields() != null && !field.getChildFields().isEmpty()) {
-                field.setChildFields(convertFields(field.getChildFields()));
-            }
+
         }
         return fields;
     }

--- a/reporting/src/test/java/org/cardanofoundation/lob/app/reporting/viewConverter/converter/IncomeStatementConverterTest.java
+++ b/reporting/src/test/java/org/cardanofoundation/lob/app/reporting/viewConverter/converter/IncomeStatementConverterTest.java
@@ -58,4 +58,58 @@ class IncomeStatementConverterTest {
         assertEquals(BigDecimal.TEN, childFields.getFirst().getValue());
     }
 
+    @Test
+    void convertResponse_doesNotRecurseIntoChildFields() {
+        // grandchild under childA — old code would recurse and potentially alter child values
+        ReportFieldDto grandchild = new ReportFieldDto(10L, "Grandchild", BigDecimal.ONE, List.of());
+        ReportFieldDto childA = new ReportFieldDto(5L, "Child A", BigDecimal.valueOf(2), List.of(grandchild));
+        ReportFieldDto field1 = new ReportFieldDto(1L, "Field 1", BigDecimal.valueOf(5), List.of(childA));
+
+        // childC has a grandchild — old code recursed and accumulated childC as (childB + childC)
+        ReportFieldDto grandchild2 = new ReportFieldDto(11L, "Grandchild 2", BigDecimal.valueOf(99), List.of());
+        ReportFieldDto childB = new ReportFieldDto(6L, "Child B", BigDecimal.valueOf(3), List.of());
+        ReportFieldDto childC = new ReportFieldDto(7L, "Child C", BigDecimal.valueOf(4), List.of(grandchild2));
+        ReportFieldDto field2 = new ReportFieldDto(2L, "Field 2", BigDecimal.valueOf(10), List.of(childB, childC));
+
+        ReportResponseDto response = mock(ReportResponseDto.class);
+        when(response.getError()).thenReturn(Optional.empty());
+        when(response.getFields()).thenReturn(List.of(field1, field2));
+
+        IncomeStatementConverter converter = new IncomeStatementConverter();
+        ReportResponseDto result = converter.convertResponse(response);
+
+        List<ReportFieldDto> resultFields = result.getFields();
+        // Top-level accumulation still works: field2 = field1 + field2 = 5 + 10 = 15
+        assertEquals(BigDecimal.valueOf(5), resultFields.get(0).getValue());
+        assertEquals(BigDecimal.valueOf(15), resultFields.get(1).getValue());
+
+        // Child fields must NOT be recursively accumulated
+        // childA is the only child of field1 (i=0), so no accumulation expected
+        assertEquals(BigDecimal.valueOf(2), resultFields.get(0).getChildFields().get(0).getValue());
+        // childB is the first child of field2, no accumulation
+        assertEquals(BigDecimal.valueOf(3), resultFields.get(1).getChildFields().get(0).getValue());
+        // childC has a grandchild — old code would have set childC = childB + childC = 3 + 4 = 7; new code leaves it as 4
+        assertEquals(BigDecimal.valueOf(4), resultFields.get(1).getChildFields().get(1).getValue());
+    }
+
+    @Test
+    void convertResponse_fieldsWithoutChildrenAreNotAccumulated() {
+        ReportFieldDto field1 = new ReportFieldDto(1L, "Field 1", BigDecimal.valueOf(10), List.of());
+        ReportFieldDto field2 = new ReportFieldDto(2L, "Field 2", BigDecimal.valueOf(20), List.of());
+        ReportFieldDto field3 = new ReportFieldDto(3L, "Field 3", BigDecimal.valueOf(30), List.of());
+
+        ReportResponseDto response = mock(ReportResponseDto.class);
+        when(response.getError()).thenReturn(Optional.empty());
+        when(response.getFields()).thenReturn(List.of(field1, field2, field3));
+
+        IncomeStatementConverter converter = new IncomeStatementConverter();
+        ReportResponseDto result = converter.convertResponse(response);
+
+        List<ReportFieldDto> resultFields = result.getFields();
+        // None have child fields, so the accumulation condition is never met — all values unchanged
+        assertEquals(BigDecimal.valueOf(10), resultFields.get(0).getValue());
+        assertEquals(BigDecimal.valueOf(20), resultFields.get(1).getValue());
+        assertEquals(BigDecimal.valueOf(30), resultFields.get(2).getValue());
+    }
+
 }


### PR DESCRIPTION
In the Income Statement report, the hierarchical calculation logic is broken. While the structure should follow a Lines → Subsection → Section aggregation path, one or more subsections in the Production environment are incorrectly aggregating the totals of the subsections that appear above them in the report order.